### PR TITLE
Homecooked fix

### DIFF
--- a/dmriprep/workflows/dwi/base.py
+++ b/dmriprep/workflows/dwi/base.py
@@ -730,7 +730,7 @@ def init_base_wf(
 
             wf_multi_run_name = "%s%s%s%s" % ('wf_multi_run_', participant, '_', session)
             wf = pe.Workflow(name=wf_multi_run_name)
-            wf.base_dir = work_dir + '/' + wf_multi_run_name
+            wf.base_dir = work_dir / ('/' + wf_multi_run_name)
             if not os.path.isdir(wf.base_dir):
                 os.mkdir(wf.base_dir)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ python_requires = >=3.5
 install_requires =
     dipy ~=1.0.0
     indexed_gzip >=0.8.8
+    llvmlite <= 0.32.1
     nibabel >=2.2.1
     nilearn !=0.5.0, !=0.5.1
     nipype >=1.2.1


### PR DESCRIPTION
Two fixes:

1) For multi-run pathing, it tried to add a Path obj and string which doesnt work, but now fixed.
2) An issue with newer versions of llvmlite. See [issue](https://github.com/rapidsai/cuml/issues/2389). Placed upper limit on llvmlite version.